### PR TITLE
Added tap to focus

### DIFF
--- a/lib/providers/instructionProvider.dart
+++ b/lib/providers/instructionProvider.dart
@@ -7,12 +7,20 @@ class Instruction with ChangeNotifier {
   InstructionMetadata? _instructionMetadata;
   String _instructionMarkdown = LOADING_MESSAGE;
   bool _fromPrediction = false;
+  bool _firstLoad = false;
 
   InstructionMetadata? get instructionMetadata => _instructionMetadata;
 
   String get instructionMarkdown => _instructionMarkdown;
 
   bool get fromPrediction => _fromPrediction;
+
+  bool get firstLoad => _firstLoad;
+
+  set firstLoad(bool value) {
+    _firstLoad = value;
+    notifyListeners();
+  }
 
   void resetInstruction() {
     _instructionMarkdown = LOADING_MESSAGE;
@@ -29,7 +37,6 @@ class Instruction with ChangeNotifier {
 
   void setInstructionMarkdown(String instructionMarkdown) async {
     _instructionMarkdown = instructionMarkdown;
-    _fromPrediction = fromPrediction;
     notifyListeners();
   }
 }

--- a/lib/screens/cameraScreen.dart
+++ b/lib/screens/cameraScreen.dart
@@ -176,8 +176,8 @@ class _CameraScreenState extends State<CameraScreen>
               setState(() {
                 isLoading = false;
               });
-              widget.panelController.animatePanelToSnapPoint();
               widget.scrollController.jumpTo(0);
+              widget.panelController.animatePanelToSnapPoint();
             } catch (e) {
               print(e);
             }

--- a/lib/screens/cameraScreen.dart
+++ b/lib/screens/cameraScreen.dart
@@ -38,8 +38,8 @@ class _CameraScreenState extends State<CameraScreen> {
   String? imagePath;
 
   Future<void> _onTap(TapUpDetails details) async {
-    if (widget.cameraController.value.isInitialized) {
-      // Your existing onTap code here
+    if (!isLoading && widget.cameraController.value.isInitialized) {
+      // Remove widget and hide instructions on tap functionality
       context.read<ImagePath>().resetImagePath();
       setState(() {
         imagePath = null;
@@ -56,8 +56,7 @@ class _CameraScreenState extends State<CameraScreen> {
       });
 
       double fullWidth = MediaQuery.of(context).size.width;
-      double cameraHeight =
-          fullWidth / widget.cameraController.value.aspectRatio;
+      double cameraHeight = MediaQuery.of(context).size.height;
 
       double xp = _x / fullWidth;
       double yp = _y / cameraHeight;
@@ -93,11 +92,19 @@ class _CameraScreenState extends State<CameraScreen> {
             onTapUp: _onTap,
             child: Stack(
               children: [
+                // 0. Transparent overlay to capture taps in whole screen
+                Container(
+                  color: Colors.transparent,
+                ),
+
+                // 1. Camera Preview
                 Transform.scale(
                   scale: scale,
                   alignment: Alignment.topCenter,
                   child: CameraPreview(widget.cameraController),
                 ),
+
+                // 2. Focus Circle
                 if (_showFocusCircle)
                   Positioned(
                     top: _y - 20,

--- a/lib/screens/feedbackScreen.dart
+++ b/lib/screens/feedbackScreen.dart
@@ -86,7 +86,7 @@ class _MyFormWidgetState extends State<MyFormWidget> {
                 EdgeInsets.only(bottom: 16.0), // Add desired padding/margin
             child: TextFieldTags(
               textfieldTagsController: widget.inputController,
-              textSeparators: const [' ', ','],
+              textSeparators: const [','],
               inputfieldBuilder:
                   (context, tec, fn, error, onChanged, onSubmitted) {
                 return ((context, sc, tags, onTagDelete) {

--- a/lib/screens/homepageScreen.dart
+++ b/lib/screens/homepageScreen.dart
@@ -4,12 +4,13 @@ import 'package:camera/camera.dart';
 import 'package:firebase_ml_model_downloader/firebase_ml_model_downloader.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:recyclingapp/entities/instructionMetadata.dart';
+import 'package:provider/provider.dart';
 import 'package:recyclingapp/screens/cameraScreen.dart';
 import 'package:recyclingapp/screens/informationScreen.dart';
 import 'package:recyclingapp/screens/mapScreen.dart';
 import 'package:sliding_up_panel2/sliding_up_panel2.dart';
 
+import '../providers/instructionProvider.dart';
 import '../utils/neuralNetworkConnector.dart';
 import '../widgets/instructionContent.dart';
 import 'loadingScreen.dart';
@@ -50,16 +51,13 @@ class _HomepageState extends State<Homepage> {
     });
   }
 
-  void _onSwitchToMapScreen(InstructionMetadata instructionMetadata) {
+  void _onSwitchToMapScreen(BuildContext context) {
     setState(() {
       index = 2;
-      screens[2] = MapScreen(
-          panelController: panelController,
-          scrollController: scrollController,
-          instructionMetadata: instructionMetadata);
     });
-    panelController.animatePanelToSnapPoint();
+    context.read<Instruction>().firstLoad = true;
     scrollController.jumpTo(0);
+    panelController.animatePanelToSnapPoint();
   }
 
   @override

--- a/lib/screens/mapScreen.dart
+++ b/lib/screens/mapScreen.dart
@@ -40,6 +40,7 @@ class _MapScreenState extends State<MapScreen> with TickerProviderStateMixin {
   List<InstructionMetadata> _instructions = [];
   List<RecyclableMaterial> _materials = [];
   double _rotation = 0;
+  late AnimationController _controller;
 
   @override
   void initState() {
@@ -47,6 +48,12 @@ class _MapScreenState extends State<MapScreen> with TickerProviderStateMixin {
     setMaterials();
     _mapController = MapController();
     centerMap(_mapController, widget.instructionMetadata);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 
   void _animatedMapMove(LatLng destLocation, double destZoom, double rotation) {
@@ -57,24 +64,17 @@ class _MapScreenState extends State<MapScreen> with TickerProviderStateMixin {
     final zoomTween = Tween<double>(begin: _mapController.zoom, end: destZoom);
     final rotationTween =
         Tween<double>(begin: _mapController.rotation, end: rotation);
-    final controller = AnimationController(
+    _controller = AnimationController(
         duration: const Duration(milliseconds: 500), vsync: this);
     final Animation<double> animation =
-        CurvedAnimation(parent: controller, curve: Curves.fastOutSlowIn);
-    controller.addListener(() {
+        CurvedAnimation(parent: _controller, curve: Curves.fastOutSlowIn);
+    _controller.addListener(() {
       _mapController.move(
           LatLng(latTween.evaluate(animation), lngTween.evaluate(animation)),
           zoomTween.evaluate(animation));
       _mapController.rotate(rotationTween.evaluate(animation));
     });
-    animation.addStatusListener((status) {
-      if (status == AnimationStatus.completed) {
-        controller.dispose();
-      } else if (status == AnimationStatus.dismissed) {
-        controller.dispose();
-      }
-    });
-    controller.forward();
+    _controller.forward();
   }
 
   @override

--- a/lib/screens/mapScreen.dart
+++ b/lib/screens/mapScreen.dart
@@ -24,7 +24,7 @@ class MapScreen extends StatefulWidget {
   });
 
   final PanelController panelController;
-  final InstructionMetadata? instructionMetadata;
+  InstructionMetadata? instructionMetadata;
 
   @override
   State<StatefulWidget> createState() => _MapScreenState();
@@ -202,6 +202,7 @@ class _MapScreenState extends State<MapScreen> with TickerProviderStateMixin {
         _latLng = latLng;
         _rotation = _mapController.rotation;
         _materialName = instructionMetadata.materialName;
+        widget.instructionMetadata = null;
       });
     } else {
       final Location location = Location();

--- a/lib/widgets/instructionContent.dart
+++ b/lib/widgets/instructionContent.dart
@@ -114,6 +114,8 @@ Widget instructionContent(ScrollController sc, BuildContext context,
                     Colors.blueGrey,
                     () {
                       onScreenChange(instructionMetadata);
+                      // Con esto hacemos que haga scroll de la instrucción
+                      // hasta arriba en el cambio de pantalla.
                       sc.animateTo(
                         0,
                         duration: const Duration(milliseconds: 500),

--- a/lib/widgets/instructionContent.dart
+++ b/lib/widgets/instructionContent.dart
@@ -40,7 +40,7 @@ void sendFeedback(BuildContext context, PanelController? panelController,
   );
 }
 
-typedef void OnScreenChangeCallback(InstructionMetadata instructionMetadata);
+typedef void OnScreenChangeCallback(BuildContext context);
 
 Widget instructionContent(
     ScrollController scrollController,
@@ -116,10 +116,7 @@ Widget instructionContent(
                     Icons.map_outlined,
                     Colors.blueGrey,
                     () {
-                      onScreenChange(instructionMetadata);
-                      // Con esto hacemos que haga scroll de la instrucción
-                      // hasta arriba en el cambio de pantalla.
-                      scrollController.jumpTo(0);
+                      onScreenChange(context);
                     },
                   ),
               ],


### PR DESCRIPTION
Added tap to focus circle when touching the camera preview screen.
Also fixed the behaviour when going to the map screen from the instruction from the camera. Now the instruction content is emptied after switching the screen so that if we go back to it we see all the instructions and the map is centered in my location instead of using the location and filter of the previous instruction